### PR TITLE
Add format puppet-lint

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -17,6 +17,8 @@
 // 		eslint-compact	(eslint -f compact) A fully pluggable tool for identifying and reporting on patterns in JavaScript - https://github.com/eslint/eslint
 // 	php
 // 		phpstan	(phpstan --errorFormat=raw) PHP Static Analysis Tool - discover bugs in your code without running it! - https://github.com/phpstan/phpstan
+// 	puppet
+// 		puppet-lint	Check that your Puppet manifests conform to the style guide - https://github.com/rodjek/puppet-lint
 // 	python
 // 		pep8	Python style guide checker - https://pypi.python.org/pypi/pep8
 // 	ruby

--- a/fmts/puppet.go
+++ b/fmts/puppet.go
@@ -1,0 +1,15 @@
+package fmts
+
+func init() {
+	const lang = "puppet"
+
+	register(&Fmt{
+		Name: "puppet-lint",
+		Errorformat: []string{
+			`%f - %m on line %l`,
+		},
+		Description: "Check that your Puppet manifests conform to the style guide",
+		URL:         "https://github.com/rodjek/puppet-lint",
+		Language:    lang,
+	})
+}

--- a/fmts/testdata/puppet-lint.in
+++ b/fmts/testdata/puppet-lint.in
@@ -1,0 +1,5 @@
+/modules/manifests/install.pp - ERROR: docker::install not in autoload module layout on line 7
+/modules/manifests/init.pp - ERROR: docker not in autoload module layout on line 347
+/modules/manifests/registry_auth.pp - ERROR: docker::registry_auth not in autoload module layout on line 2
+/modules/manifests/systemd_reload.pp - ERROR: docker::systemd_reload not in autoload module layout on line 5
+/modules/manifests/image.pp - ERROR: docker::image not in autoload module layout on line 26

--- a/fmts/testdata/puppet-lint.ok
+++ b/fmts/testdata/puppet-lint.ok
@@ -1,0 +1,5 @@
+/modules/manifests/install.pp|7| ERROR: docker::install not in autoload module layout
+/modules/manifests/init.pp|347| ERROR: docker not in autoload module layout
+/modules/manifests/registry_auth.pp|2| ERROR: docker::registry_auth not in autoload module layout
+/modules/manifests/systemd_reload.pp|5| ERROR: docker::systemd_reload not in autoload module layout
+/modules/manifests/image.pp|26| ERROR: docker::image not in autoload module layout


### PR DESCRIPTION
I want to Add puppet-lint(http://puppet-lint.com/) format.
Puppet is an opensource software configuration management tool.

Would you please review this?

Thank you.