### PR TITLE
Fix fmts package path

### DIFF
--- a/fmts/gendoc.go
+++ b/fmts/gendoc.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/haya14busa/errorformat/fmts"
+	"../fmts"
 )
 
 func main() {


### PR DESCRIPTION
Because fmts package import from github, `$ go generate ./...`  don't correctly generate new doc even if adding a new errorformat.
This PR has changed to import the fmts package from local, so that doc can be generated correctly.

Would you please review this?

Thank you.

