### PR TITLE
Get golint tool from `golang.org/x/lint/golint`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - go get github.com/haya14busa/goverage
   # Install linters.
   - go get github.com/haya14busa/reviewdog/cmd/reviewdog
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/kisielk/errcheck
   - go get honnef.co/go/tools/cmd/gosimple
   - go get honnef.co/go/tools/cmd/staticcheck


### PR DESCRIPTION
Travis logs:
```
$ go get github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
The command "go get github.com/golang/lint/golint" failed and exited with 1 during .
```
I change CI configuration to use `golang.org/x/lint/golint` instead of `github.com/golang/lint/golint`
Would you please review this?

Thank you.