### PR TITLE
CI: travis: use go master, 1.11.x and 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.8
+  - 1.10.x
+  - 1.11.x
   - master
 
 install:


### PR DESCRIPTION
Related on https://github.com/haya14busa/errorformat/issues/29

Change the version of golang used in the test in order to return the test to normal.
Would you please review this?

Thank you.