### PR TITLE
Fix rubocop url

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -22,7 +22,7 @@
 // 	python
 // 		pep8	Python style guide checker - https://pypi.python.org/pypi/pep8
 // 	ruby
-// 		rubocop	A Ruby static code analyzer, based on the community Ruby style guide - https://github.com/bbatsov/rubocop
+// 		rubocop	A Ruby static code analyzer, based on the community Ruby style guide - https://github.com/rubocop-hq/rubocop
 // 	scala
 // 		sbt	the interactive build tool - http://www.scala-sbt.org/
 // 		sbt-scalastyle	Scalastyle - SBT plugin - http://www.scalastyle.org/sbt.html

--- a/fmts/ruby.go
+++ b/fmts/ruby.go
@@ -12,7 +12,7 @@ func init() {
 			`%-G%.%#`,
 		},
 		Description: "A Ruby static code analyzer, based on the community Ruby style guide",
-		URL:         "https://github.com/bbatsov/rubocop",
+		URL:         "https://github.com/rubocop-hq/rubocop",
 		Language:    lang,
 	})
 


### PR DESCRIPTION
rubocop moved to rubocop-hq organization.

https://github.com/rubocop-hq/rubocop