### PR TITLE
Add dotenv-linter

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -9,6 +9,8 @@
 // 
 // 	css
 // 		stylelint	A mighty modern CSS linter - https://github.com/stylelint/stylelint
+// 	env
+// 		dotenv-linter	Linter for .env files - https://github.com/mgrachev/dotenv-linter
 // 	go
 // 		golangci-lint	(golangci-lint run --out-format=line-number) GolangCI-Lint is a linters aggregator. - https://github.com/golangci/golangci-lint
 // 		golint	linter for Go source code - https://github.com/golang/lint

--- a/fmts/env.go
+++ b/fmts/env.go
@@ -1,0 +1,15 @@
+package fmts
+
+func init() {
+	const lang = "env"
+
+	register(&Fmt{
+		Name: "dotenv-linter",
+		Errorformat: []string{
+			`%f:%l %m`,
+		},
+		Description: "Linter for .env files",
+		URL:         "https://github.com/mgrachev/dotenv-linter",
+		Language:    lang,
+	})
+}

--- a/fmts/ruby.go
+++ b/fmts/ruby.go
@@ -27,7 +27,7 @@ func init() {
 		Language:    lang,
 	})
 
-  register(&Fmt{
+	register(&Fmt{
 		Name: "brakeman",
 		Errorformat: []string{
 			`%f%*\s%l%*\s%m`,

--- a/fmts/testdata/dotenv-linter.in
+++ b/fmts/testdata/dotenv-linter.in
@@ -1,0 +1,5 @@
+.env:1 Leading space detected
+.env:2 The FOO key should be with a value or have an equal sign
+.env:3 The FOO-BAR key has incorrect delimiter
+.env:4 The FOo_BAR key should be in uppercase
+.env:5 The foo_bar key should be in uppercase

--- a/fmts/testdata/dotenv-linter.ok
+++ b/fmts/testdata/dotenv-linter.ok
@@ -1,0 +1,5 @@
+.env|1| Leading space detected
+.env|2| The FOO key should be with a value or have an equal sign
+.env|3| The FOO-BAR key has incorrect delimiter
+.env|4| The FOo_BAR key should be in uppercase
+.env|5| The foo_bar key should be in uppercase

--- a/writer/checkstyle.go
+++ b/writer/checkstyle.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/reviewdog/errorformat"
 	"github.com/haya14busa/go-checkstyle/checkstyle"
+	"github.com/reviewdog/errorformat"
 )
 
 // CheckStyle represents checkstyle XML writer. http://checkstyle.sourceforge.net/


### PR DESCRIPTION
[dotenv-linter](https://github.com/mgrachev/dotenv-linter) - It's a linter for `.env` files.
