### PR TITLE
Add go-consistent 

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -14,6 +14,7 @@
 // 	env
 // 		dotenv-linter	Linter for .env files - https://github.com/mgrachev/dotenv-linter
 // 	go
+// 		go-consistent	Source code analyzer that helps you to make your Go programs more consistent - https://github.com/quasilyte/go-consistent
 // 		golangci-lint	(golangci-lint run --out-format=line-number) GolangCI-Lint is a linters aggregator. - https://github.com/golangci/golangci-lint
 // 		golint	linter for Go source code - https://github.com/golang/lint
 // 		govet	Vet examines Go source code and reports suspicious problems - https://golang.org/cmd/vet/

--- a/fmts/go.go
+++ b/fmts/go.go
@@ -35,4 +35,14 @@ func init() {
 		URL:         "https://github.com/golangci/golangci-lint",
 		Language:    lang,
 	})
+
+	register(&Fmt{
+		Name: "go-consistent",
+		Errorformat: []string{
+			`%f:%l:%c: %m`,
+		},
+		Description: "Source code analyzer that helps you to make your Go programs more consistent",
+		URL:         "https://github.com/quasilyte/go-consistent",
+		Language:    lang,
+	})
 }

--- a/fmts/testdata/go-consistent.in
+++ b/fmts/testdata/go-consistent.in
@@ -1,0 +1,16 @@
+./fmts/testdata/resources/go/go_consistent.go:29:6: zero value ptr alloc: use new(T) for *T allocation
+./fmts/testdata/resources/go/go_consistent.go:31:6: zero value ptr alloc: use new(T) for *T allocation
+./fmts/testdata/resources/go/go_consistent.go:38:6: empty slice: use make([]T, 0)
+./fmts/testdata/resources/go/go_consistent.go:45:6: empty map: use make(map[K]V)
+./fmts/testdata/resources/go/go_consistent.go:52:6: hex lit: use a-f (lower case) digits
+./fmts/testdata/resources/go/go_consistent.go:60:6: range check: use align-left, like in `x >= low && x <= high`
+./fmts/testdata/resources/go/go_consistent.go:67:6: and-not: remove a space between & and ^, like in `x &^ y`
+./fmts/testdata/resources/go/go_consistent.go:75:6: float lit: use explicit int/frac part, like in `1.0` and `0.1`
+./fmts/testdata/resources/go/go_consistent.go:77:6: float lit: use explicit int/frac part, like in `1.0` and `0.1`
+./fmts/testdata/resources/go/go_consistent.go:84:1: label case: use ALL_UPPER
+./fmts/testdata/resources/go/go_consistent.go:86:1: label case: use ALL_UPPER
+./fmts/testdata/resources/go/go_consistent.go:99:2: untyped const coerce: specify type in LHS, like in `var x T = const`
+./fmts/testdata/resources/go/go_consistent.go:113:2: arg list parens: align `)` to a same line with last argument
+./fmts/testdata/resources/go/go_consistent.go:136:6: non-zero length test: use `len(s) != 0`
+./fmts/testdata/resources/go/go_consistent.go:138:6: non-zero length test: use `len(s) != 0`
+./fmts/testdata/resources/go/go_consistent.go:154:2: default case order: default case should be the first case

--- a/fmts/testdata/go-consistent.ok
+++ b/fmts/testdata/go-consistent.ok
@@ -1,0 +1,16 @@
+./fmts/testdata/resources/go/go_consistent.go|29 col 6| zero value ptr alloc: use new(T) for *T allocation
+./fmts/testdata/resources/go/go_consistent.go|31 col 6| zero value ptr alloc: use new(T) for *T allocation
+./fmts/testdata/resources/go/go_consistent.go|38 col 6| empty slice: use make([]T, 0)
+./fmts/testdata/resources/go/go_consistent.go|45 col 6| empty map: use make(map[K]V)
+./fmts/testdata/resources/go/go_consistent.go|52 col 6| hex lit: use a-f (lower case) digits
+./fmts/testdata/resources/go/go_consistent.go|60 col 6| range check: use align-left, like in `x >= low && x <= high`
+./fmts/testdata/resources/go/go_consistent.go|67 col 6| and-not: remove a space between & and ^, like in `x &^ y`
+./fmts/testdata/resources/go/go_consistent.go|75 col 6| float lit: use explicit int/frac part, like in `1.0` and `0.1`
+./fmts/testdata/resources/go/go_consistent.go|77 col 6| float lit: use explicit int/frac part, like in `1.0` and `0.1`
+./fmts/testdata/resources/go/go_consistent.go|84 col 1| label case: use ALL_UPPER
+./fmts/testdata/resources/go/go_consistent.go|86 col 1| label case: use ALL_UPPER
+./fmts/testdata/resources/go/go_consistent.go|99 col 2| untyped const coerce: specify type in LHS, like in `var x T = const`
+./fmts/testdata/resources/go/go_consistent.go|113 col 2| arg list parens: align `)` to a same line with last argument
+./fmts/testdata/resources/go/go_consistent.go|136 col 6| non-zero length test: use `len(s) != 0`
+./fmts/testdata/resources/go/go_consistent.go|138 col 6| non-zero length test: use `len(s) != 0`
+./fmts/testdata/resources/go/go_consistent.go|154 col 2| default case order: default case should be the first case

--- a/fmts/testdata/resources/go/go_consistent.go
+++ b/fmts/testdata/resources/go/go_consistent.go
@@ -1,0 +1,158 @@
+package test
+
+// In this test suite, (1) option is always preferred.
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+//= unit import: omit parenthesis in a single-package import
+
+var (
+	_ = fmt.Printf
+	_ = errors.New
+	_ = strconv.Atoi
+)
+
+// T is an example type.
+type T struct {
+	integer int
+}
+
+func zeroValPtrAlloc() {
+	_ = new(T)
+	_ = new(map[string]bool)
+	_ = new([]int)
+	//= zero value ptr alloc: use new(T) for *T allocation
+	_ = &T{}
+	//= zero value ptr alloc: use new(T) for *T allocation
+	_ = &[]int{}
+}
+
+func emptySlice() {
+	_ = make([]int, 0)
+	_ = make([]float64, 0)
+	//= empty slice: use make([]T, 0)
+	_ = []string{}
+}
+
+func emptyMap() {
+	_ = make(map[T]T)
+	_ = make(map[*T]*T, 0)
+	//= empty map: use make(map[K]V)
+	_ = map[int]int{}
+}
+
+func hexLit() {
+	_ = 0xff
+	_ = 0xabcdef
+	//= hex lit: use a-f (lower case) digits
+	_ = 0xABCD
+}
+
+func rangeCheck(x, low, high int) {
+	_ = x > low && x <= high
+	_ = x+1 >= low && x+1 < high
+	_ = x >= low && x <= high
+	//= range check: use align-left, like in `x >= low && x <= high`
+	_ = low < x || x < high
+}
+
+func andNot(x, y int) {
+	_ = x &^ y
+	_ = 123 &^ x
+	//= and-not: remove a space between & and ^, like in `x &^ y`
+	_ = (x + 100) & ^(y + 2)
+}
+
+func floatLit() {
+	_ = 0.0
+	_ = 0.123
+	_ = 1.0
+	//= float lit: use explicit int/frac part, like in `1.0` and `0.1`
+	_ = 0.
+	//= float lit: use explicit int/frac part, like in `1.0` and `0.1`
+	_ = .0
+}
+
+func labelCase() {
+ALL_UPPER:
+FOO:
+	//= label case: use ALL_UPPER
+UpperCamelCase:
+	//= label case: use ALL_UPPER
+lowerCamelCase:
+	goto ALL_UPPER
+	goto FOO
+	goto UpperCamelCase
+	goto lowerCamelCase
+}
+
+func untypedConstCoerce() {
+	const zero = 0
+
+	var _ int = zero
+	var _ int32 = 10
+	//= untyped const coerce: specify type in LHS, like in `var x T = const`
+	var _ = int64(zero + 1)
+}
+
+func threeArgs(a, b, c int) {}
+
+func argListParens() {
+	threeArgs(
+		1,
+		2,
+		3)
+	threeArgs(1,
+		2,
+		3)
+	//= arg list parens: align `)` to a same line with last argument
+	threeArgs(
+		1,
+		2,
+		3,
+	)
+}
+
+func nonZeroLenTestChecker() {
+	var (
+		s  string
+		b  []byte
+		m  map[int]int
+		ch chan int
+	)
+
+	// Strings are ignored.
+	_ = len(s) >= 1
+	_ = len(s) >= 1
+	_ = len(s) >= 1
+
+	_ = len(b) != 0
+	_ = len(m) != 0
+	//= non-zero length test: use `len(s) != 0`
+	_ = len(ch) > 0
+	//= non-zero length test: use `len(s) != 0`
+	_ = len(ch) >= 1
+}
+
+func defaultCaseOrder(x int, v interface{}) {
+	switch x {
+	default:
+	case 10:
+	}
+
+	switch v.(type) {
+	default:
+	case int:
+	case string:
+	}
+
+	//= default case order: default case should be the first case
+	switch {
+	case x > 20:
+	default:
+	}
+}


### PR DESCRIPTION
# Background
Try to add `go-consistent` support to `reviewdog`
**Related issue:** https://github.com/quasilyte/go-consistent/issues/33

**PS:** I am not the author of `go-consistent`. **That's why I would also request review from the author too.**

# Error format
The input file is generated by the [test data](https://github.com/quasilyte/go-consistent/blob/master/testdata/positive_tests1.go). 
The line generating this log is from [here](https://github.com/quasilyte/go-consistent/blob/master/main.go#L264). Since there is no configuration file, there should be only one error format.