### PR TITLE
Add standard js

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -23,6 +23,7 @@
 // 	javascript
 // 		eslint	(eslint [-f stylish]) A fully pluggable tool for identifying and reporting on patterns in JavaScript - https://github.com/eslint/eslint
 // 		eslint-compact	(eslint -f compact) A fully pluggable tool for identifying and reporting on patterns in JavaScript - https://github.com/eslint/eslint
+// 		standardjs	(standard) JavaScript style guide, linter, and formatter - https://github.com/standard/standard
 // 	php
 // 		phpstan	(phpstan --error-format=raw) PHP Static Analysis Tool - discover bugs in your code without running it! - https://github.com/phpstan/phpstan
 // 	puppet

--- a/fmts/javascript.go
+++ b/fmts/javascript.go
@@ -29,4 +29,15 @@ func init() {
 		Language:    lang,
 	})
 
+	register(&Fmt{
+		Name: "standardjs",
+		Errorformat: []string{
+			`%*\s%f:%l:%c: %m`,
+			`%-G%.%#`,
+		},
+		Description: "(standard) JavaScript style guide, linter, and formatter",
+		URL:         "https://github.com/standard/standard",
+		Language:    lang,
+	})
+
 }

--- a/fmts/testdata/standardjs.in
+++ b/fmts/testdata/standardjs.in
@@ -1,0 +1,13 @@
+standard: Use JavaScript Standard Style (https://standardjs.com)
+standard: Run `standard --fix` to automatically fix some problems.
+  /project/app/javascript/controllers/notification_controller.js:4:12: Missing space before function parentheses.
+  /project/app/javascript/controllers/subscription_controller.js:8:21: Strings must use singlequote.
+  /project/app/javascript/controllers/subscription_controller.js:16:40: Extra semicolon.
+  /project/app/javascript/controllers/subscription_controller.js:35:14: Missing space before function parentheses.
+  /project/app/javascript/controllers/subscription_controller.js:39:19: Missing space before function parentheses.
+  /project/app/javascript/controllers/subscription_controller.js:43:21: Missing space before function parentheses.
+  /project/app/javascript/controllers/subscription_controller.js:48:43: Extra semicolon.
+  /project/app/javascript/controllers/subscription_controller.js:49:51: Extra semicolon.
+  /project/app/javascript/controllers/subscription_controller.js:53:39: Extra semicolon.
+  /project/app/javascript/controllers/subscription_controller.js:54:46: Extra semicolon.
+  /project/app/javascript/controllers/subscription_controller.js:65:65: Extra semicolon.

--- a/fmts/testdata/standardjs.ok
+++ b/fmts/testdata/standardjs.ok
@@ -1,0 +1,11 @@
+/project/app/javascript/controllers/notification_controller.js|4 col 12| Missing space before function parentheses.
+/project/app/javascript/controllers/subscription_controller.js|8 col 21| Strings must use singlequote.
+/project/app/javascript/controllers/subscription_controller.js|16 col 40| Extra semicolon.
+/project/app/javascript/controllers/subscription_controller.js|35 col 14| Missing space before function parentheses.
+/project/app/javascript/controllers/subscription_controller.js|39 col 19| Missing space before function parentheses.
+/project/app/javascript/controllers/subscription_controller.js|43 col 21| Missing space before function parentheses.
+/project/app/javascript/controllers/subscription_controller.js|48 col 43| Extra semicolon.
+/project/app/javascript/controllers/subscription_controller.js|49 col 51| Extra semicolon.
+/project/app/javascript/controllers/subscription_controller.js|53 col 39| Extra semicolon.
+/project/app/javascript/controllers/subscription_controller.js|54 col 46| Extra semicolon.
+/project/app/javascript/controllers/subscription_controller.js|65 col 65| Extra semicolon.


### PR DESCRIPTION
[Standard JS](https://standardjs.com/) is a wrapper of ESLint, but it has a different output format from ESLint, I bet that users would love to have it by default 😄 