### PR TITLE
Fix bug of missing filename if multiline (C,Z)

### DIFF
--- a/errorformat.go
+++ b/errorformat.go
@@ -355,6 +355,9 @@ func (s *Scanner) parseLineInternal(line string, i int) (qfstatus, *qffields) {
 				if fields.etype != 0 && qfprev.Type == 0 {
 					qfprev.Type = rune(fields.etype)
 				}
+				if qfprev.Filename == "" {
+					qfprev.Filename = fields.namebuf
+				}
 				if qfprev.Lnum == 0 {
 					qfprev.Lnum = fields.lnum
 				}

--- a/errorformat_test.go
+++ b/errorformat_test.go
@@ -230,6 +230,15 @@ README.md
 				"/path/to/file| error| oneline error for the file 2",
 			},
 		},
+		{
+			efm: []string{
+				`%EMultilineError`,
+				`%Z%f:%l:%c`,
+			},
+			in: `MultilineError
+~/.vimrc:1:2`,
+			want: []string{"~/.vimrc|1 col 2 error|"},
+		},
 	}
 nexttext:
 	for _, tt := range tests {


### PR DESCRIPTION
Fix following bug.

```
--- FAIL: TestScanner_Scan (0.00s)
    errorformat_test.go:261: %EMultilineError,%Z%f:%l:%c:0:
        got:  "|1 col 2 error|"
        want: "~/.vimrc|1 col 2 error|"
FAIL
```