### PR TITLE
:sparkles: Adds flake8 fmt

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -38,6 +38,7 @@
 // 	puppet
 // 		puppet-lint	Check that your Puppet manifests conform to the style guide - https://github.com/rodjek/puppet-lint
 // 	python
+// 		flake8	Tool for python style guide enforcement - https://flake8.pycqa.org/
 // 		pep8	Python style guide checker - https://pypi.python.org/pypi/pep8
 // 	ruby
 // 		brakeman	(brakeman --quiet --format tabs) A static analysis security vulnerability scanner for Ruby on Rails applications - https://github.com/presidentbeef/brakeman

--- a/fmts/python.go
+++ b/fmts/python.go
@@ -12,4 +12,14 @@ func init() {
 		URL:         "https://pypi.python.org/pypi/pep8",
 		Language:    lang,
 	})
+
+	register(&Fmt{
+		Name: "flake8",
+		Errorformat: []string{
+			`%f:%l:%c: %t%n %m`,
+		},
+		Description: "Tool for python style guide enforcement",
+		URL:         "https://flake8.pycqa.org/",
+		Language:    lang,
+	})
 }

--- a/fmts/testdata/flake8.in
+++ b/fmts/testdata/flake8.in
@@ -1,0 +1,30 @@
+./num_guess.py:4:1: F401 'sys' imported but unused
+./num_guess.py:4:11: E261 at least two spaces before inline comment
+./num_guess.py:5:1: F401 'os' imported but unused
+./num_guess.py:5:10: E261 at least two spaces before inline comment
+./num_guess.py:7:1: E266 too many leading '#' for block comment
+./num_guess.py:9:80: E501 line too long (82 > 79 characters)
+./num_guess.py:17:77: E261 at least two spaces before inline comment
+./num_guess.py:17:80: E501 line too long (118 > 79 characters)
+./num_guess.py:43:1: E402 module level import not at top of file
+./num_guess.py:43:1: F401 'itertools' imported but unused
+./num_guess.py:43:17: E261 at least two spaces before inline comment
+./num_guess.py:43:63: W292 no newline at end of file
+./subfolder/queen_problem.py:3:1: F401 'pwd' imported but unused
+./subfolder/queen_problem.py:3:11: E261 at least two spaces before inline comment
+./subfolder/queen_problem.py:4:1: F401 'grp' imported but unused
+./subfolder/queen_problem.py:4:11: E261 at least two spaces before inline comment
+./subfolder/queen_problem.py:8:1: E266 too many leading '#' for block comment
+./subfolder/queen_problem.py:10:80: E501 line too long (80 > 79 characters)
+./subfolder/queen_problem.py:13:1: E302 expected 2 blank lines, found 1
+./subfolder/queen_problem.py:16:1: E302 expected 2 blank lines, found 1
+./subfolder/queen_problem.py:17:36: E261 at least two spaces before inline comment
+./subfolder/queen_problem.py:17:80: E501 line too long (100 > 79 characters)
+./subfolder/queen_problem.py:23:1: E302 expected 2 blank lines, found 1
+./subfolder/queen_problem.py:36:1: E305 expected 2 blank lines after class or function definition, found 1
+./subfolder/queen_problem.py:37:6: E211 whitespace before '('
+./subfolder/queen_problem.py:38:6: E211 whitespace before '('
+./subfolder/queen_problem.py:40:1: E402 module level import not at top of file
+./subfolder/queen_problem.py:40:1: F401 'dis' imported but unused
+./subfolder/queen_problem.py:40:11: E261 at least two spaces before inline comment
+./subfolder/queen_problem.py:40:57: W292 no newline at end of file

--- a/fmts/testdata/flake8.ok
+++ b/fmts/testdata/flake8.ok
@@ -1,0 +1,30 @@
+./num_guess.py|4 col 1 F 401| 'sys' imported but unused
+./num_guess.py|4 col 11 error 261| at least two spaces before inline comment
+./num_guess.py|5 col 1 F 401| 'os' imported but unused
+./num_guess.py|5 col 10 error 261| at least two spaces before inline comment
+./num_guess.py|7 col 1 error 266| too many leading '#' for block comment
+./num_guess.py|9 col 80 error 501| line too long (82 > 79 characters)
+./num_guess.py|17 col 77 error 261| at least two spaces before inline comment
+./num_guess.py|17 col 80 error 501| line too long (118 > 79 characters)
+./num_guess.py|43 col 1 error 402| module level import not at top of file
+./num_guess.py|43 col 1 F 401| 'itertools' imported but unused
+./num_guess.py|43 col 17 error 261| at least two spaces before inline comment
+./num_guess.py|43 col 63 warning 292| no newline at end of file
+./subfolder/queen_problem.py|3 col 1 F 401| 'pwd' imported but unused
+./subfolder/queen_problem.py|3 col 11 error 261| at least two spaces before inline comment
+./subfolder/queen_problem.py|4 col 1 F 401| 'grp' imported but unused
+./subfolder/queen_problem.py|4 col 11 error 261| at least two spaces before inline comment
+./subfolder/queen_problem.py|8 col 1 error 266| too many leading '#' for block comment
+./subfolder/queen_problem.py|10 col 80 error 501| line too long (80 > 79 characters)
+./subfolder/queen_problem.py|13 col 1 error 302| expected 2 blank lines, found 1
+./subfolder/queen_problem.py|16 col 1 error 302| expected 2 blank lines, found 1
+./subfolder/queen_problem.py|17 col 36 error 261| at least two spaces before inline comment
+./subfolder/queen_problem.py|17 col 80 error 501| line too long (100 > 79 characters)
+./subfolder/queen_problem.py|23 col 1 error 302| expected 2 blank lines, found 1
+./subfolder/queen_problem.py|36 col 1 error 305| expected 2 blank lines after class or function definition, found 1
+./subfolder/queen_problem.py|37 col 6 error 211| whitespace before '('
+./subfolder/queen_problem.py|38 col 6 error 211| whitespace before '('
+./subfolder/queen_problem.py|40 col 1 error 402| module level import not at top of file
+./subfolder/queen_problem.py|40 col 1 F 401| 'dis' imported but unused
+./subfolder/queen_problem.py|40 col 11 error 261| at least two spaces before inline comment
+./subfolder/queen_problem.py|40 col 57 warning 292| no newline at end of file

--- a/fmts/testdata/resources/python/num_guess.py
+++ b/fmts/testdata/resources/python/num_guess.py
@@ -1,0 +1,43 @@
+"""Small test script taken from https://wiki.python.org/moin/SimplePrograms"""
+
+import random
+import sys # F401 'os' imported but unused
+import os # F401 'os' imported but unused
+
+### E265 block comment should start with '# '
+print("Hello from reviewdog!")
+print("Let's play a small number guessing game to test the flake8 github action.")
+print("This game is taken from https://wiki.python.org/moin/SimplePrograms.")
+
+guesses_made = 0
+
+name = input("Hello! What is your name?\n")
+
+number = random.randint(1, 20)
+print("Well, {0}, I am thinking of a number between 1 and 20.".format(name)) # E501 line too long (80 > 79 characters)
+
+while guesses_made < 6:
+
+    guess = int(input("Take a guess: "))
+
+    guesses_made += 1
+
+    if guess < number:
+        print("Your guess is too low.")
+
+    if guess > number:
+        print("Your guess is too high.")
+
+    if guess == number:
+        break
+
+if guess == number:
+    print(
+        "Good job, {0}! You guessed my number in {1} guesses!".format(
+            name, guesses_made
+        )
+    )
+else:
+    print("Nope. The number I was thinking of was {0}".format(number))
+
+import itertools # E402 module level import not at top of file

--- a/fmts/testdata/resources/python/subfolder/queen_problem.py
+++ b/fmts/testdata/resources/python/subfolder/queen_problem.py
@@ -1,0 +1,40 @@
+"""Small test script taken from https://wiki.python.org/moin/SimplePrograms"""
+
+import pwd # F401 'os' imported but unused
+import grp # F401 'os' imported but unused
+
+BOARD_SIZE = 8
+
+### E265 block comment should start with '# '
+print("Hello from reviewdog!")
+print("Let's play a small queen problem game to test the flake8 github action.")
+print("This game is taken from https://wiki.python.org/moin/SimplePrograms.")
+
+class BailOut(Exception):
+    pass
+
+def validate(queens):
+    left = right = col = queens[-1] # E501 line too long (80 > 79 characters). Long description text
+    for r in reversed(queens[:-1]):
+        left, right = left-1, right+1
+        if r in (left, col, right):
+            raise BailOut
+
+def add_queen(queens):
+    for i in range(BOARD_SIZE):
+        test_queens = queens + [i]
+        try:
+            validate(test_queens)
+            if len(test_queens) == BOARD_SIZE:
+                return test_queens
+            else:
+                return add_queen(test_queens)
+        except BailOut:
+            pass
+    raise BailOut
+
+queens = add_queen([])
+print (queens)
+print ("\n".join(". "*q + "Q " + ". "*(BOARD_SIZE-q-1) for q in queens))
+
+import dis # E402 module level import not at top of file


### PR DESCRIPTION
I added the flake8 error format. See https://flake8.pycqa.org/en/latest/ for more information. This format is very similar to the pep8 format but I thought it would still be useful to add the distinction.