### PR TITLE
:sparkles: Adds black formatter format support

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -38,6 +38,7 @@
 // 	puppet
 // 		puppet-lint	Check that your Puppet manifests conform to the style guide - https://github.com/rodjek/puppet-lint
 // 	python
+// 		black	A uncompromising Python code formatter - https://github.com/psf/black
 // 		flake8	Tool for python style guide enforcement - https://flake8.pycqa.org/
 // 		pep8	Python style guide checker - https://pypi.python.org/pypi/pep8
 // 	ruby

--- a/fmts/python.go
+++ b/fmts/python.go
@@ -22,4 +22,17 @@ func init() {
 		URL:         "https://flake8.pycqa.org/",
 		Language:    lang,
 	})
+
+	register(&Fmt{
+		Name: "black",
+		Errorformat: []string{
+			`%-GOh no!%.%#`,
+			`%-G%\d\+ files%.%#`,
+			`%m %f`,
+			`%-G%.%#`,
+		},
+		Description: "A uncompromising Python code formatter",
+		URL:         "https://github.com/psf/black",
+		Language:    lang,
+	})
 }

--- a/fmts/testdata/black.in
+++ b/fmts/testdata/black.in
@@ -1,0 +1,4 @@
+would reformat /home/ricks/Development/personal/errorformat/fmts/testdata/resources/python/num_guess.py
+would reformat /home/ricks/Development/personal/errorformat/fmts/testdata/resources/python/subfolder/queen_problem.py
+Oh no! 💥 💔 💥
+2 files would be reformatted.

--- a/fmts/testdata/black.ok
+++ b/fmts/testdata/black.ok
@@ -1,0 +1,2 @@
+/home/ricks/Development/personal/errorformat/fmts/testdata/resources/python/num_guess.py|| would reformat
+/home/ricks/Development/personal/errorformat/fmts/testdata/resources/python/subfolder/queen_problem.py|| would reformat


### PR DESCRIPTION
This commits add the output of the [black formatter](https://github.com/psf/black) to the supported formats.