### PR TITLE
:bug: Fixes small black format syntax error

### DIFF
--- a/fmts/python.go
+++ b/fmts/python.go
@@ -28,6 +28,7 @@ func init() {
 		Errorformat: []string{
 			`%-GOh no!%.%#`,
 			`%-G%\d\+ files%.%#`,
+			`%-GAll done!%.%#`,
 			`%m %f`,
 			`%-G%.%#`,
 		},

--- a/fmts/testdata/black.in
+++ b/fmts/testdata/black.in
@@ -2,3 +2,4 @@ would reformat /home/ricks/Development/personal/errorformat/fmts/testdata/resour
 would reformat /home/ricks/Development/personal/errorformat/fmts/testdata/resources/python/subfolder/queen_problem.py
 Oh no! 💥 💔 💥
 2 files would be reformatted.
+All done! ✨ 🍰 ✨


### PR DESCRIPTION
This pull request makes sure the black success message is not parsed as an error.