### PR TITLE
Add Staticcheck error fmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Folders to ignore
 .vscode/
+.idea/
 
 # Files to ignore
 .drone.sec.yaml

--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -22,6 +22,7 @@
 // 		golint	linter for Go source code - https://github.com/golang/lint
 // 		gosec	(gosec -fmt=golint) Golang Security Checker - https://github.com/securego/gosec
 // 		govet	Vet examines Go source code and reports suspicious problems - https://golang.org/cmd/vet/
+// 		staticcheck	Golang Static Analysis - https://staticcheck.io
 // 	haml
 // 		haml-lint	Tool for writing clean and consistent HAML - https://github.com/sds/haml-lint
 // 	haskell

--- a/fmts/go.go
+++ b/fmts/go.go
@@ -55,4 +55,14 @@ func init() {
 		URL:         "https://github.com/securego/gosec",
 		Language:    lang,
 	})
+
+	register(&Fmt{
+		Name:        "staticcheck",
+		Errorformat: []string{
+			"%f:%l:%c: %m",
+		},
+		Description: "Golang Static Analysis",
+		URL:         "https://staticcheck.io",
+		Language:    lang,
+	})
 }

--- a/fmts/testdata/staticcheck.in
+++ b/fmts/testdata/staticcheck.in
@@ -1,0 +1,6 @@
+test.go:9:9: empty branch (SA9003)
+test.go:9:13: identical expressions on the left and right side of the '==' operator (SA4000)
+test.go:15:2: should replace loop with y = append(y, x...) (S1011)
+test.go:16:7: this result of append is never used, except maybe in other appends (SA4010)
+test.go:19:2: Sprintf is a pure function but its return value is ignored (SA4017)
+test.go:19:2: the argument is already a string, there's no need to use fmt.Sprintf (S1025)

--- a/fmts/testdata/staticcheck.ok
+++ b/fmts/testdata/staticcheck.ok
@@ -1,0 +1,6 @@
+test.go|9 col 9| empty branch (SA9003)
+test.go|9 col 13| identical expressions on the left and right side of the '==' operator (SA4000)
+test.go|15 col 2| should replace loop with y = append(y, x...) (S1011)
+test.go|16 col 7| this result of append is never used, except maybe in other appends (SA4010)
+test.go|19 col 2| Sprintf is a pure function but its return value is ignored (SA4017)
+test.go|19 col 2| the argument is already a string, there's no need to use fmt.Sprintf (S1025)


### PR DESCRIPTION
In preparation of the changes to the reviewdog/action-staticcheck mentioned in this [PR](https://github.com/reviewdog/action-staticcheck/pull/14), I added the staticcheck error format. So that the staticcheck action doesn't rely on the `jq` binary anymore. 