### PR TITLE
fixed: typo

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -32,7 +32,7 @@
 // 		eslint-compact	(eslint -f compact) A fully pluggable tool for identifying and reporting on patterns in JavaScript - https://github.com/eslint/eslint
 // 		standardjs	(standard) JavaScript style guide, linter, and formatter - https://github.com/standard/standard
 // 	lua
-// 		luacheck	(luacheck --format=plain) Lua linter and static analyzer - https://github.com/luarocks/luacheck
+// 		luacheck	(luacheck --formatter=plain) Lua linter and static analyzer - https://github.com/luarocks/luacheck
 // 	markdown
 // 		remark-lint	Tool for writing clean and consistent markdown code - https://github.com/remarkjs/remark-lint
 // 	php

--- a/fmts/lua.go
+++ b/fmts/lua.go
@@ -8,7 +8,7 @@ func init() {
 		Errorformat: []string{
 			`%f:%l:%c: %m`,
 		},
-		Description: "(luacheck --format=plain) Lua linter and static analyzer",
+		Description: "(luacheck --formatter=plain) Lua linter and static analyzer",
 		URL:         "https://github.com/luarocks/luacheck",
 		Language:    lang,
 	})


### PR DESCRIPTION
sorry for the typo in doc, `format` should be `formatter`