### PR TITLE
Change the type of error type from rune to string

### DIFF
--- a/errorformat_test.go
+++ b/errorformat_test.go
@@ -267,15 +267,15 @@ nexttext:
 
 func TestEntry_Types(t *testing.T) {
 	tests := []struct {
-		t    rune
+		t    string
 		nr   int
 		want string
 	}{
-		{t: 'e', want: "error"},
-		{t: 'E', want: "error"},
-		{t: 'e', nr: 14, want: "error 14"},
-		{t: 'w', nr: 14, want: "warning 14"},
-		{t: 'i', want: "info"},
+		{t: "e", want: "error"},
+		{t: "E", want: "error"},
+		{t: "e", nr: 14, want: "error 14"},
+		{t: "w", nr: 14, want: "warning 14"},
+		{t: "i", want: "info"},
 		{nr: 14, want: "error 14"},
 	}
 	for _, tt := range tests {

--- a/fmts/css.go
+++ b/fmts/css.go
@@ -7,7 +7,7 @@ func init() {
 		Name: "stylelint",
 		Errorformat: []string{
 			`%-P%f`,
-			`%*[\ ]%l:%c%*[\ ]%*[✖⚠]%*[\ ]%m`,
+			`%*[\ ]%l:%c%*[\ ]%t%*[\ ]%m`,
 			`%-Q`,
 		},
 		Description: "A mighty modern CSS linter",

--- a/fmts/testdata/stylelint.ok
+++ b/fmts/testdata/stylelint.ok
@@ -1,11 +1,11 @@
-renderer/style.css|46 col 3| Unexpected longhand value '0px 5px 0 5px' instead of '0px 5px 0'              shorthand-property-no-redundant-values
-renderer/style.css|46 col 12| Unexpected unit                                                               length-zero-no-unit                   
-renderer/style.css|116 col 3| Unexpected longhand value '0 5px 0 5px' instead of '0 5px'                    shorthand-property-no-redundant-values
-renderer/style.css|145 col 16| Unexpected unit                                                               length-zero-no-unit                   
-renderer/style.css|146 col 13| Unexpected unit                                                               length-zero-no-unit                   
-renderer/style.css|151 col 17| Unexpected unit                                                               length-zero-no-unit                   
-renderer/style.css|152 col 3| Unexpected longhand value '0px 16px 100px 16px' instead of '0px 16px 100px'   shorthand-property-no-redundant-values
-renderer/style.css|152 col 13| Unexpected unit                                                               length-zero-no-unit                   
-renderer/style.css|166 col 18| Unexpected unit                                                               length-zero-no-unit                   
-renderer/style.css|182 col 1| Expected empty line before non-nested rule                                    rule-non-nested-empty-line-before     
-renderer/style.css|200 col 1| Expected empty line before non-nested rule                                    rule-non-nested-empty-line-before
+renderer/style.css|46 col 3 error| Unexpected longhand value '0px 5px 0 5px' instead of '0px 5px 0'              shorthand-property-no-redundant-values
+renderer/style.css|46 col 12 warning| Unexpected unit                                                               length-zero-no-unit                   
+renderer/style.css|116 col 3 error| Unexpected longhand value '0 5px 0 5px' instead of '0 5px'                    shorthand-property-no-redundant-values
+renderer/style.css|145 col 16 warning| Unexpected unit                                                               length-zero-no-unit                   
+renderer/style.css|146 col 13 warning| Unexpected unit                                                               length-zero-no-unit                   
+renderer/style.css|151 col 17 warning| Unexpected unit                                                               length-zero-no-unit                   
+renderer/style.css|152 col 3 error| Unexpected longhand value '0px 16px 100px 16px' instead of '0px 16px 100px'   shorthand-property-no-redundant-values
+renderer/style.css|152 col 13 warning| Unexpected unit                                                               length-zero-no-unit                   
+renderer/style.css|166 col 18 warning| Unexpected unit                                                               length-zero-no-unit                   
+renderer/style.css|182 col 1 error| Expected empty line before non-nested rule                                    rule-non-nested-empty-line-before     
+renderer/style.css|200 col 1 error| Expected empty line before non-nested rule                                    rule-non-nested-empty-line-before

--- a/writer/checkstyle.go
+++ b/writer/checkstyle.go
@@ -37,8 +37,8 @@ func (c *CheckStyle) Write(e *errorformat.Entry) error {
 		Message:  e.Text,
 		Severity: e.Types(),
 	}
-	if e.Nr != 0 && e.Type != 0 {
-		checkerr.Source = fmt.Sprintf("%s%d", string(e.Type), e.Nr)
+	if e.Nr != 0 && e.Type != "" {
+		checkerr.Source = fmt.Sprintf("%s%d", e.Type, e.Nr)
 	}
 	c.files[e.Filename].Errors = append(c.files[e.Filename].Errors, checkerr)
 	return nil

--- a/writer/jsonl_test.go
+++ b/writer/jsonl_test.go
@@ -8,8 +8,8 @@ func ExampleJSONL() {
 		w.Write(e)
 	}
 	// Output:
-	// {"filename":"path/to/file1","lnum":1,"col":14,"vcol":false,"nr":0,"pattern":"","text":"hello","type":87,"valid":false,"lines":["path/to/file1:1:14:[W] hello"]}
-	// {"filename":"path/to/file1","lnum":2,"col":14,"vcol":false,"nr":0,"pattern":"","text":"vim","type":73,"valid":false,"lines":["path/to/file1:2:14:[I] vim"]}
-	// {"filename":"file2","lnum":2,"col":14,"vcol":false,"nr":1,"pattern":"","text":"emacs","type":69,"valid":false,"lines":["file2:2:14:[E] emacs"]}
-	// {"filename":"file2","lnum":14,"col":1,"vcol":false,"nr":14,"pattern":"","text":"neovim","type":69,"valid":false,"lines":["file2:14:1:[E] neovim"]}
+	// {"filename":"path/to/file1","lnum":1,"col":14,"vcol":false,"nr":0,"pattern":"","text":"hello","type":"W","valid":false,"lines":["path/to/file1:1:14:[W] hello"]}
+	// {"filename":"path/to/file1","lnum":2,"col":14,"vcol":false,"nr":0,"pattern":"","text":"vim","type":"I","valid":false,"lines":["path/to/file1:2:14:[I] vim"]}
+	// {"filename":"file2","lnum":2,"col":14,"vcol":false,"nr":1,"pattern":"","text":"emacs","type":"E","valid":false,"lines":["file2:2:14:[E] emacs"]}
+	// {"filename":"file2","lnum":14,"col":1,"vcol":false,"nr":14,"pattern":"","text":"neovim","type":"E","valid":false,"lines":["file2:14:1:[E] neovim"]}
 }

--- a/writer/sarif.go
+++ b/writer/sarif.go
@@ -44,11 +44,11 @@ func (s *Sarif) Write(e *errorformat.Entry) error {
 
 	// Set Level
 	switch e.Type {
-	case 'e', 'E':
+	case "e", "E", "✖":
 		result.Level = sarif.Error.Ptr()
-	case 'w', 'W':
+	case "w", "W", "⚠":
 		result.Level = sarif.Warning.Ptr()
-	case 'n', 'N', 'i', 'I': // Handle info as note.
+	case "n", "N", "i", "I": // Handle info as note.
 		result.Level = sarif.Note.Ptr()
 	}
 

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 var testErrs = []*errorformat.Entry{
-	{Filename: "path/to/file1", Lnum: 1, Col: 14, Text: "hello", Type: 'W'},
-	{Filename: "path/to/file1", Lnum: 2, Col: 14, Text: "vim", Type: 'I'},
-	{Filename: "file2", Lnum: 2, Col: 14, Text: "emacs", Type: 'E', Nr: 1},
-	{Filename: "file2", Lnum: 14, Col: 1, Text: "neovim", Type: 'E', Nr: 14},
+	{Filename: "path/to/file1", Lnum: 1, Col: 14, Text: "hello", Type: "W"},
+	{Filename: "path/to/file1", Lnum: 2, Col: 14, Text: "vim", Type: "I"},
+	{Filename: "file2", Lnum: 2, Col: 14, Text: "emacs", Type: "E", Nr: 1},
+	{Filename: "file2", Lnum: 14, Col: 1, Text: "neovim", Type: "E", Nr: 14},
 }
 
 func init() {
 	for _, e := range testErrs {
 		e.Lines = append(e.Lines, fmt.Sprintf("%s:%d:%d:[%s] %s",
-			e.Filename, e.Lnum, e.Col, string(e.Type), e.Text))
+			e.Filename, e.Lnum, e.Col, e.Type, e.Text))
 	}
 }


### PR DESCRIPTION
When using Stylelint, ✖ , ⚠  is used to distinguish Error and Warning.
At present, it was not possible to distinguish because rune type was used to type of error, but it was distinguished by changing to string type.