### PR TITLE
Add support for Python mypy

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -44,6 +44,7 @@
 // 		black	A uncompromising Python code formatter - https://github.com/psf/black
 // 		flake8	Tool for python style guide enforcement - https://flake8.pycqa.org/
 // 		isort	A Python utility / library to sort Python imports - https://github.com/PyCQA/isort
+// 		mypy	An optional static type checker for Python - http://mypy-lang.org/
 // 		pep8	Python style guide checker - https://pypi.python.org/pypi/pep8
 // 	ruby
 // 		brakeman	(brakeman --quiet --format tabs) A static analysis security vulnerability scanner for Ruby on Rails applications - https://github.com/presidentbeef/brakeman

--- a/fmts/python.go
+++ b/fmts/python.go
@@ -49,4 +49,17 @@ func init() {
 		URL:         "https://github.com/PyCQA/isort",
 		Language:    lang,
 	})
+
+	register(&Fmt{
+		Name: "mypy",
+		Errorformat: []string{
+		    `%f:%l: %trror: %m`,
+            `%f:%l: %tarning: %m`,
+            `%f:%l: %tnfo: %m`,
+            `%f:%l: %tote: %m`,
+		},
+		Description: "An optional static type checker for Python",
+		URL:         "http://mypy-lang.org/",
+		Language:    lang,
+	})
 }

--- a/fmts/testdata/mypy.in
+++ b/fmts/testdata/mypy.in
@@ -1,0 +1,4 @@
+/path/to/my/file.py:123: error: Error message!
+/path/to/another/file.py:234: warning: Warning message with $ characters!
+/path/to/third/file.py:1: info: Only nice to have
+file.py:99999: note: A very long and elaborate error message with ! lot $ of % special characters äöüß...

--- a/fmts/testdata/mypy.ok
+++ b/fmts/testdata/mypy.ok
@@ -1,0 +1,4 @@
+/path/to/my/file.py|123 error| Error message!
+/path/to/another/file.py|234 warning| Warning message with $ characters!
+/path/to/third/file.py|1 info| Only nice to have
+file.py|99999 note| A very long and elaborate error message with ! lot $ of % special characters äöüß...


### PR DESCRIPTION
# Summary

- Adds a errorlog style for Python [mypy](http://www.mypy-lang.org/) ([Github](https://github.com/python/mypy)).
- Tested the error code with the [online playground](https://reviewdog.github.io/errorformat-playground/?efms=%25f%3A%25l%3A+%25trror%3A+%25m%0A%25f%3A%25l%3A+%25tarning%3A+%25m%0A%25f%3A%25l%3A+%25tnfo%3A+%25m%0A%25f%3A%25l%3A+%25tote%3A+%25m%0A&text=%2Fpath%2Fto%2Fmy%2Ffile.py%3A123%3A+error%3A+Error+message%21%0A%2Fpath%2Fto%2Fanother%2Ffile.py%3A234%3A+warning%3A+Warning+message+with+%24+characters%21%0A%2Fpath%2Fto%2Fthird%2Ffile.py%3A1%3A+info%3A+Only+nice+to+have%0Afile.py%3A99999%3A+note%3A+A+very+long+and+elaborate+error+message+with+%21+lot+%24+of+%25+special+characters+%C3%A4%C3%B6%C3%BC%C3%9F...%0A).
- The `mypy.ok` file was taken from a copy of `mypy.out`.
