### PR TITLE
add protolint support

### DIFF
--- a/fmts/doc.go
+++ b/fmts/doc.go
@@ -38,6 +38,8 @@
 // 	php
 // 		phpstan	(phpstan --error-format=raw) PHP Static Analysis Tool - discover bugs in your code without running it! - https://github.com/phpstan/phpstan
 // 		psalm	(psalm --output-format=text) Psalm is a static analysis tool for finding errors in PHP - https://github.com/vimeo/psalm
+// 	protocolbuffer
+// 		protolint	A pluggable linting utility for Protocol Buffer files - https://github.com/yoheimuta/protolint
 // 	puppet
 // 		puppet-lint	Check that your Puppet manifests conform to the style guide - https://github.com/rodjek/puppet-lint
 // 	python

--- a/fmts/protocolbuffer.go
+++ b/fmts/protocolbuffer.go
@@ -1,0 +1,15 @@
+package fmts
+
+func init() {
+	const lang = "protocolbuffer"
+
+	register(&Fmt{
+		Name: "protolint",
+		Errorformat: []string{
+			`[%f:%l:%c] %m`,
+		},
+		Description: "A pluggable linting utility for Protocol Buffer files",
+		URL:         "https://github.com/yoheimuta/protolint",
+		Language:    lang,
+	})
+}

--- a/fmts/testdata/protolint.in
+++ b/fmts/testdata/protolint.in
@@ -1,0 +1,3 @@
+[protolint.new.proto:1:1] File name should be lower_snake_case.proto.
+[protolint.new.proto:11:5] Found an incorrect indentation style "    ". "  " is correct.
+[protolint.new.proto:12:5] Found an incorrect indentation style "    ". "  " is correct.

--- a/fmts/testdata/protolint.ok
+++ b/fmts/testdata/protolint.ok
@@ -1,0 +1,3 @@
+protolint.new.proto|1 col 1| File name should be lower_snake_case.proto.
+protolint.new.proto|11 col 5| Found an incorrect indentation style "    ". "  " is correct.
+protolint.new.proto|12 col 5| Found an incorrect indentation style "    ". "  " is correct.


### PR DESCRIPTION
# What
add [protolint](https://github.com/yoheimuta/protolint) support
# QA
add protolint.ok and protolint.out
run `go generate ./...  `

`go test ./...` fails at 'cmd/errorformat', but I am not sure this failure is due to my change, because tests of fmts pass

```text
ok      github.com/reviewdog/errorformat        (cached)
FAIL    github.com/reviewdog/errorformat/cmd/errorformat [build failed]
ok      github.com/reviewdog/errorformat/fmts   0.282s
ok      github.com/reviewdog/errorformat/writer (cached)
FAIL
```