### PR TITLE
refactor: go-vet alert fix.

### DIFF
--- a/cmd/errorformat/main.go
+++ b/cmd/errorformat/main.go
@@ -67,7 +67,7 @@ syntax of package template.  The default output is equivalent to -f
 `
 
 func usage() {
-	fmt.Fprintln(os.Stderr, usageMessage)
+	fmt.Fprintf(os.Stderr, "%s", usageMessage)
 	fmt.Fprintln(os.Stderr, "Flags:")
 	flag.PrintDefaults()
 	os.Exit(2)


### PR DESCRIPTION
In go-vet, Fprintln function is not allowed below context:
- possible formatting directive %f
- redundant newline 
Thus, use Fprintf instead of Fprintln.